### PR TITLE
docs: example of tooling used to create bounding box

### DIFF
--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -35,6 +35,8 @@ We can now create a subset of the planet file, `my_area.pmtiles`, with just tile
 pmtiles extract https://build.protomaps.com/20231001.pmtiles my_area.pmtiles --bbox=4.742883,51.830755,5.552837,52.256198
 ```
 
+> **Note:** You can find the bounding box of your own area, using tools, such as [http://bboxfinder.com/](http://bboxfinder.com/#51.830755,4.742883,52.256198,5.552837)
+
 ## 4. View the basemap
 
 [maps.protomaps.com](https://maps.protomaps.com) is a viewer for basemaps. Drag our file `my_area.pmtiles` onto the `Drop Zone` to view the map:


### PR DESCRIPTION
This is a link that was on a link provided by Simon Willison:

- https://til.simonwillison.net/gis/pmtiles

It was linked to me, by the very friendly, incredibly useful:

`@djh@chaos.social`

It was not in your docs, and I think it will help people. Especially those who notice the changing of coordinate order between CLI invocation and URL for bboxfinder.com