### PR TITLE
Update downloads and leaflet docs

### DIFF
--- a/basemaps/downloads.md
+++ b/basemaps/downloads.md
@@ -9,27 +9,27 @@ outline: deep
 
 The **Protomaps Basemap** is a general purpose vector *base map* - city labels, roads, water features and other essential location context derived from [OpenStreetMap](https://openstreetmap.org). It's available as a single PMTiles archive, distributed as an [Open Database License](https://opendatacommons.org/licenses/odbl/) Produced Work (OpenStreetMap attribution required)
 
+A full planet file is roughly **120 gigabytes**, including zoom levels from 0 to 15.
+
+Please note that **URLs may change** and hotlinking to these downloads are discouraged. Instead, you should copy the tileset to your own [Cloud Storage](/pmtiles/cloud-storage).
+
+* The generation of the planet basemap is open source at [github.com/protomaps/basemaps](http://github.com/protomaps/basemaps).
+
+
 ## Current Version
 
 The Version 3 Protomaps basemap daily build channel is available at [maps.protomaps.com/builds](https://maps.protomaps.com/builds).
 
-A mirror in the AWS `us-west-2` is available on [Source Cooperative (beta)](https://beta.source.coop) at the [protomaps/openstreetmap](https://beta.source.coop/repositories/protomaps/openstreetmap/) repository. This mirrors the recent build only.
+A mirror in the AWS `us-west-2` is available on [Source Cooperative (beta)](https://beta.source.coop) at the [protomaps/openstreetmap](https://beta.source.coop/repositories/protomaps/openstreetmap/) repository. This mirrors the most recent daily build only.
 
 ## Partial Downloads
 
 To download a cutout of a specific region, rather than the entire world map, see the CLI's [extract command](/pmtiles/cli#extract).
 
+If you don't need all 16 zoom levels of detail, use the `--maxzoom` option of `pmtiles extract`. Each additional zoom level roughly doubles the size of the file.
+
 ## Previous Version
 
 The version 2 basemap is `protomaps-basemap-opensource-20230408.pmtiles`
 
-The [protomaps-leaflet](https://github.com/protomaps/protomaps-leaflet) Leaflet plugin currently uses this basemap version.
-
-You can download the planet archive at this link (⚠ file is over 100GB):
-
 [https://r2-public.protomaps.com/protomaps-sample-datasets/protomaps-basemap-opensource-20230408.pmtiles](https://r2-public.protomaps.com/protomaps-sample-datasets/protomaps-basemap-opensource-20230408.pmtiles)
-
-Please note that this **URL may change** and hotlinking to it is discouraged. Instead, you should copy the tileset to your own [Cloud Storage](/pmtiles/cloud-storage).
-
-* The generation of the planet basemap is open source at [github.com/protomaps/basemaps](http://github.com/protomaps/basemaps).
-

--- a/basemaps/leaflet.md
+++ b/basemaps/leaflet.md
@@ -5,6 +5,21 @@ outline: deep
 
 # Basemaps for Leaflet
 
-::: warning
-This section is under construction.
-:::
+The simplest way to include a map in your application via script includes tag:
+
+```js
+// check for the latest version on github...
+<script src="https://unpkg.com/protomaps@2.0.1/dist/protomaps-leaflet.min.js"></script>
+<script>
+    const map = L.map('map')
+    var layer = protomapsL.leafletLayer({url:'FILE.pmtiles OR ENDPOINT/{z}/{x}/{y}.mvt', theme: 'light'})
+    layer.addTo(map)
+</script>
+```
+
+## Themes
+
+The `theme` option must be one of `light`, `dark`, `white`, `grayscale`, `black`.
+
+This will assume the set of basemap layers described at [Basemap Layers](/basemaps/layers).
+

--- a/pmtiles/leaflet.md
+++ b/pmtiles/leaflet.md
@@ -22,31 +22,15 @@ const p = new PMTiles('https://example.com/data.pmtiles');
 leafletRasterLayer(p).addTo(map)
 ````
 
-## Vector: protomaps-leaflet
+## Vector PMTiles
 
 Protomaps publishes a lightweight Leaflet plugin, [protomaps-leaflet](https://github.com/protomaps/protomaps-leaflet), that implements **vector drawing and text labels** built on the Canvas API and Web Fonts.
 
-:::warning
-Note: the protomaps-leaflet default style uses the Protomaps [Basemap tileset verson 2.](/basemaps/downloads)
-:::
+Note that the protomaps-leaflet library is **designed for non-interactive layers**, because it renders vector tiles to Canvas (image) elements.
 
-## Vector Basemaps
+For basemap display as a substitute for server-rendered tiles, see [Basemaps for Leaflet](/basemaps/leaflet).
 
-The simplest way to include a map in your application via script includes tag:
-
-```js
-// check for the latest version on github...
-<script src="https://unpkg.com/protomaps@1.22.0/dist/protomaps-leaflet.min.js"></script>
-<script>
-    const map = L.map('map')
-    var layer = protomapsL.leafletLayer({url:'FILE.pmtiles OR ENDPOINT/{z}/{x}/{y}.mvt'})
-    layer.addTo(map)
-</script>
-```
-
-By default, this will assume the set of basemap layers described at [Basemap Layers](/basemaps/layers), so you should see a map that looks like this:
-
-![detroit](https://protomaps.github.io/protomaps-leaflet/benchmark/example_1.png)
+For fully interactive vector overlay tiles you should use [MapLibre GL JS](/pmtiles/maplibre).
 
 ## Custom Vector Data
 
@@ -70,8 +54,8 @@ let LABEL_RULES = []; // ignore for now
 
 protomapsL.leafletLayer({
     url:URL,
-    paint_rules:PAINT_RULES,
-    label_rules:LABEL_RULES
+    paintRules:PAINT_RULES,
+    labelRules:LABEL_RULES
 }).addTo(map) 
 ```
 


### PR DESCRIPTION
protomaps-leaflet is on version 2 now, which uses the current v3 tileset
