### PR TITLE
Fixed typo in CORS:Google Cloud Shell command

### DIFF
--- a/pmtiles/cloud-storage.md
+++ b/pmtiles/cloud-storage.md
@@ -109,7 +109,7 @@ S3 CORS Configuration:
 
 ```
 echo '[{"maxAgeSeconds": 300, "method": ["GET", "HEAD"], "origin": ["https://example.com"], "responseHeader": ["range","etag","if-match"]}]' > cors.json
-gsutil cors set gcors.json gs://my-bucket-name
+gsutil cors set cors.json gs://my-bucket-name
 ```
 
 #### CORS: gsutil tool


### PR DESCRIPTION
Thank you for the great work on this project and the detailed documentation @bdon.

I noticed this typo when I was trying to setup CORS for a pmtiles file I hosted on Google Cloud Bucket.

I copied the code direclty from the docs and pasted it in Cloud Shell, but it didn't work. I spent quiet some time troubleshooting before I noticed the typo :(

This PR intends to fix that.
