### PR TITLE
Added examples on tippecanoe tile-join and ogr2ogr pmtiles conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vitepress/cache
 .vitepress/dist
 .DS_Store
+
+node_modules

--- a/pmtiles/create.md
+++ b/pmtiles/create.md
@@ -17,6 +17,13 @@ ogr2ogr -t_srs EPSG:4326 cb_2018_us_zcta510_500k.json cb_2018_us_zcta510_500k.sh
 tippecanoe -zg --projection=EPSG:4326 -o cb_2018_us_zcta510_500k_nolimit.pmtiles -l zcta cb_2018_us_zcta510_500k.json
 ```
 
+To merge multiple pmtiles files into a single file use [`tile-join` tool](https://github.com/felt/tippecanoe?tab=readme-ov-file#tile-join), which is shipped with Tippecanoe
+
+```sh
+# Merge all PMTiles files in current folder into single file
+tile-join -o merged.pmtiles *.pmtiles
+```
+
 ## MBTiles
 
 the [`pmtiles` command line tool](/pmtiles/cli) converts MBTiles to PMTiles with this command:
@@ -40,6 +47,16 @@ pmtiles convert output.mbtiles output.pmtiles
 ## GDAL
 
 GDAL has native support for PMTiles starting with version 3.8.0 (2023-11-13), see [gdal.org/drivers/vector/pmtiles](https://gdal.org/drivers/vector/pmtiles.html) for details.
+
+GDAL's [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html#ogr2ogr) tool supports a wide range of formats as input for creating PMTiles. Below is examples of generating PMTiles from a shape file and based on multiple PostgreSQL/Postgis tables.
+
+```sh
+# Convert shapefile to to pmtiles
+ogr2ogr -dsco MINZOOM=10 -dsco MAXZOOM=20 -f "PMTiles" filename.pmtiles my_shapes.shp
+
+# Merge all PostgreSQL/PostGIS tables in a schema into a single PMTiles file.
+ogr2ogr -dsco MINZOOM=0 -dsco MAXZOOM=22 -f "PMTiles" filename.pmtiles "PG:host=my_host port=my_port dbname=my_database user=my_user password=my_password schemas=my_schema"
+```
 
 ## Other
 


### PR DESCRIPTION
Based on resent work in a project using PMTiles, I missed examples on how to convert from other formats than GeoJSON to PMTiles in a single step. Luckily this can be achieved with ogr2ogr ❤️. 

Added examples for converting shape files and multiple postgres tables into a PMTiles files.

It's already added to the GDAL docs: https://gdal.org/drivers/vector/pmtiles.html#examples