### PR TITLE
aws/cloudflare: deprecate CACHE_MAX_AGE in favor of CACHE_CONTROL

### DIFF
--- a/deploy/aws.md
+++ b/deploy/aws.md
@@ -114,9 +114,10 @@ Configure these Lambda environment variables:
 * `BUCKET`: the S3 bucket name.
 * `PMTILES_PATH`: optional, define how a tileset name is translated into an S3 key. Default `{name}.pmtiles`
   * Example path setting for objects in a directory: `my_folder/{name}/file.pmtiles`
-* ~~`TILE_PATH`: optional, define the URL route of the tiles API. Default `/{name}/{z}/{x}/{y}.pbf`~~ **Deprecated**
+* ~~`TILE_PATH`: optional, define the URL route of the tiles API. Default `/{name}/{z}/{x}/{y}.pbf`~~
 * `CORS`: optional, set the value of the `Access-Control-Allow-Origin` response header. Examples: `https://example.com`, `*`. Only supports one origin, so useful for development or staging environments only. For production use you should use CloudFront CORS configuration.
-* `CACHE_MAX_AGE`: max age in the CloudFront cache, in seconds. default 86400, or 1 day.
+* ~~`CACHE_MAX_AGE`: max age in the CloudFront cache, in seconds. default 86400, or 1 day.~~
+* `CACHE_CONTROL`: HTTP header value to control caching, default `public, max-age=86400` (1 day).
 
 ## Accessing your Tiles
 

--- a/deploy/cloudflare.md
+++ b/deploy/cloudflare.md
@@ -81,13 +81,15 @@ Optional environment variables can be set set in `[vars]` of `wrangler.toml` or 
 
 * `PMTILES_PATH` - A string like `folder/{name}.pmtiles` specifying the path to archives in your bucket. Default `{name}.pmtiles`
 
-* ~~`TILES_PATH` - a string like `prefix/{name}/{z}/{x}/{y}.{ext}` specifying the tile path exposed by the worker. Default `{name}/{z}/{x}/{y}.{ext}`~~ **Deprecated**
+* ~~`TILES_PATH` - a string like `prefix/{name}/{z}/{x}/{y}.{ext}` specifying the tile path exposed by the worker. Default `{name}/{z}/{x}/{y}.{ext}`~~
 
 * `PUBLIC_HOSTNAME` - Optional, override the absolute hostname in [TileJSON](https://github.com/mapbox/tilejson-spec) responses. Example `tiles.example.com`
 
 * `ALLOWED_ORIGINS` - a comma-separated list of allowed CORS origins. Default none. Examples: `https://example.com,https://localhost:3000`, `*`
 
-* `CACHE_MAX_AGE`: max age in the Cloudflare cache, in seconds. default 86400, or 1 day.
+* ~~`CACHE_MAX_AGE`: max age in the Cloudflare cache, in seconds. default 86400, or 1 day.~~
+
+* `CACHE_CONTROL`: HTTP header value to control caching, default `public, max-age=86400` (1 day).
 
 ## Cost Estimate
 


### PR DESCRIPTION
https://github.com/protomaps/PMTiles/pull/423