### PR TITLE
Fix broken ref to MapLibre addProtocol docs

### DIFF
--- a/pmtiles/maplibre.md
+++ b/pmtiles/maplibre.md
@@ -9,7 +9,7 @@ outline: deep
 
 For reading PMTiles directly from cloud storage, you'll need the `pmtiles` JavaScript library.
 
-The JavaScript library includes a plugin for MapLibre GL that uses its [`addProtocol` feature.](https://maplibre.org/maplibre-gl-js-docs/api/properties/#addprotocol)
+The JavaScript library includes a plugin for MapLibre GL that uses its [`addProtocol` feature.](https://maplibre.org/maplibre-gl-js/docs/API/functions/addProtocol/)
 
 ```bash
 npm install pmtiles


### PR DESCRIPTION
Closes #75 

Searched across `protomaps` org to confirm this is the only reference to that URL.
Also confirmed that all other links to Maplibre docs still work.