### PR TITLE
accessibility improvements

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -6,6 +6,12 @@ export default defineConfig({
   head: [["link", { rel: "icon", type: "image/png", href: "/favicon.png" }]],
   description: "Technical Documentation for Protomaps",
   cleanUrls: true,
+  markdown: {
+    theme: {
+      light: 'github-light-high-contrast',
+      dark: 'github-dark-high-contrast'
+    }
+  },
   themeConfig: {
     logo: "/logo.svg",
     // https://vitepress.dev/reference/default-theme-config
@@ -76,7 +82,7 @@ export default defineConfig({
     socialLinks: [
       { icon: "github", link: "https://github.com/protomaps" },
       { icon: "mastodon", link: "https://mapstodon.space/@protomaps" },
-      { icon: "twitter", link: "https://twitter.com/protomaps" },
+      { icon: "bluesky", link: "https://bsky.app/profile/protomaps.com" },
     ],
 
     search: {

--- a/basemaps/downloads.md
+++ b/basemaps/downloads.md
@@ -22,6 +22,14 @@ The Version 4 Protomaps basemap daily build channel is available at [maps.protom
 
 A mirror in the AWS `us-west-2` is available on [Source Cooperative (beta)](https://beta.source.coop) at the [protomaps/openstreetmap](https://beta.source.coop/repositories/protomaps/openstreetmap/) repository. This mirrors the most recent daily build only.
 
+### Build History
+
+The daily builds bucket retains:
+
+* All builds for the past week.
+* Weekly monday builds for the past month.
+* The latest build for each version (major + minor + patch) beyond that.
+
 ## Partial Downloads
 
 To download a cutout of a specific region, rather than the entire world map, see the CLI's [extract command](/pmtiles/cli#extract).

--- a/components/CostCalculator.vue
+++ b/components/CostCalculator.vue
@@ -79,13 +79,14 @@ const cfShow = ref(false);
 
 <template>
   <div>
-    <h3>Inputs</h3>
-    <div class="well">
-      <div class="big">
-        <input v-model="formattedRequests" />monthly tile requests
+    <div>
+      <div class="text-xl">
+        <input id="requests" class="text-xl" v-model="formattedRequests" />
+        <label for="requests"> monthly tile requests</label>
       </div>
       <div>
         <input
+          aria-label="set the number of requests"
           type="range"
           id="range"
           min="0"
@@ -98,47 +99,51 @@ const cfShow = ref(false);
         <strong>{{ mapViews.toLocaleString() }}</strong> monthly map viewer
         sessions
       </div>
-      <div>
-        (one viewing session loads <input v-model.number="tilesPerView" />tiles)
+      <div class="text-sm">
+        <input id="tilesPerView" v-model.number="tilesPerView" />
+        <label for="tilesPerView"> Tile loads per viewing session</label>
       </div>
-      <div>
+      <div class="mt-4">
         <strong>{{ outgoingGB.toLocaleString() }} GB</strong> outgoing bandwidth
         to Internet
       </div>
-      <div>
-        (average tile size
-        <input v-model.number="averageTileSizeKB" />kilobytes)
+      <div class="text-sm">
+        <input id="averageTileSizeKB" v-model.number="averageTileSizeKB" />
+        <label for="averageTileSizeKB"> Average tile size in kilobytes</label>
       </div>
-      <div><input v-model.number="cacheHitRate" /> CDN cache hit rate</div>
-      <div><input v-model.number="storedGB" /> gigabytes on cloud storage</div>
+      <div class="text-sm">
+        <input v-model.number="cacheHitRate" /> CDN cache hit rate
+      </div>
+      <div class="text-sm">
+        <input v-model.number="storedGB" /> Gigabytes stored
+      </div>
     </div>
   </div>
   <div>
     <h3>Google Maps</h3>
-    <span class="cost">{{ googleCost.toFixed(2) }} USD per month</span>
-    <div>
-      (Reference:
+    <span class="text-lg">{{ googleCost.toFixed(2) }} USD per month</span>
+    <div class="text-sm">
       <a
         href="https://developers.google.com/maps/documentation/javascript/usage-and-billing"
         >SKU: Dynamic Maps</a
-      >)
+      >
     </div>
   </div>
   <div class="highlight">
     <h3>Hosted Map API</h3>
-    <span class="cost">{{ hostedCost.toFixed(2) }} USD per month</span>
-    <div>
-      (<input v-model.number="hostedPerKViews" /> USD per 1,000 sessions)
+    <span class="text-lg">{{ hostedCost.toFixed(2) }} USD per month</span>
+    <div class="text-sm">
+      <input v-model.number="hostedPerKViews" /> USD per 1,000 sessions
     </div>
   </div>
   <div class="highlight">
     <h3>Protomaps on AWS</h3>
-    <span class="cost"
+    <span class="text-lg"
       ><strong>{{ aws.total.toFixed(2) }} USD</strong> per month</span
     >
-    <div class="showBreakdown" v-on:click="awsShow = !awsShow">
+    <button class="showBreakdown" v-on:click="awsShow = !awsShow">
       {{ awsShow ? "Hide" : "Show" }} cost breakdown
-    </div>
+    </button>
     <table v-show="awsShow">
       <thead>
         <tr>
@@ -246,12 +251,12 @@ const cfShow = ref(false);
   </div>
   <div>
     <h3>Protomaps on Cloudflare</h3>
-    <span class="cost"
+    <span class="text-lg"
       ><strong>{{ cf.total.toFixed(2) }} USD</strong> per month</span
     >
-    <div class="showBreakdown" v-on:click="cfShow = !cfShow">
+    <button class="showBreakdown" v-on:click="cfShow = !cfShow">
       {{ cfShow ? "Hide" : "Show" }} cost breakdown
-    </div>
+    </button>
     <table v-show="cfShow">
       <thead>
         <tr>
@@ -331,42 +336,42 @@ const cfShow = ref(false);
 <style scoped>
 input {
   border: 1px solid #ccc;
-  width: 3rem;
-  margin-right: 0.5rem;
+  width: 2rem;
+  border-radius: 3px;
+  padding-left: 0.2rem;
 }
 
-#range {
-  width: 100%;
+.mt-4 {
+  margin-top: 2rem;
 }
 
-#notes {
-  color: #777;
+.text-sm {
+  font-size: 0.8rem;
+}
+
+.text-lg {
+  font-size: 1.2rem;
+}
+
+.text-xl {
+  font-size: 2rem;
 }
 
 .showBreakdown {
+  display: block;
   cursor: pointer;
   font-weight: 500;
   color: var(--vp-c-brand-1);
   text-decoration: underline;
 }
 
-.big,
-.big input {
-  font-size: 2rem;
-}
-
-.big input {
-  width: 15rem;
-}
-
-.well {
-  padding: 1rem;
-  background: var(--vp-sidebar-bg-color);
-  border-radius: 8px;
+#range {
   margin-top: 1rem;
+  margin-bottom: 1rem;
+  width: 100%;
 }
 
-.cost {
-  font-size: 1.2rem;
+#requests {
+  width: 15rem;
 }
 </style>


### PR DESCRIPTION
> All interactive elements should have a role, name and value. The input fields in the Cost Calculator don’t have a name (label). A screen reader will read for example ‘Edit selected 12,000,000’ but doesn’t say what information the user is providing or why. The same problem occurs on the slider: the screen reader will only read ‘Slider 1.2 + 07’.

Addressed by adding the required tags. 

> The navigation menu has nested interactive controls, because of this the navigation is harder to control for people with a visibility or mobility disability. For more information, see also nested-interactive by Accessibility Insights.

See vitepress issue 3806 below.

> You can’t reach the scrollable regions that include code snippets when using the keyboard. By using ‘tab’ on your keyboard, you should be able to cycle through all interactive elements on the page.

Keyboard scrolling on overflow divs seems to work on Chromium for Mac, but not Safari/Firefox:
![CleanShot 2025-01-06 at 17 06 40@2x](https://github.com/user-attachments/assets/ab495456-e818-4551-bc7c-cdbc457bf331)

> The contrast between foreground and background is not sufficient for grey text (#6D737C) within code snippet boxes. The minimum contrast should be 3:1.

Changed to `high-contrast` versions of the syntax themes. 

> The state of the navigation menu toggles cannot be determined programmatically: it does not contain a value or indication whether it is collapsed or expanded.

See vitepress issue 3806 below.

> When you use the keyboard to navigate through the menu, there are 2 buttons with the same action:
the text, for example ‘introduction’ and the arrow pointing down. Both these clickable buttons expand
the list of navigation items below. This might cause unnecessary confusion for people who use their
keyboard and/or a screen reader to use the page, because they can’t easily perceive the difference. A
solution could be to group the interactions to one button or remove one of them.

See https://github.com/vuejs/vitepress/pull/3806