### PR TITLE
fix: Fix invalid Cloudflare pricing calculation

### DIFF
--- a/components/CostCalculator.vue
+++ b/components/CostCalculator.vue
@@ -47,7 +47,7 @@ const cf = computed(() => {
     storageCost: storedGB.value * 0.015,
   };
   obj.total =
-    obj.workerInvocationCost + obj.planCost + obj.storageCost + obj.storageCost;
+    obj.workerInvocationCost + obj.planCost + obj.storageRequestCost + obj.storageCost;
   return obj;
 });
 


### PR DESCRIPTION
This PR fixes an issue in the Cloudflare pricing calculator where the total amount didn't include the storage request costs.

![image](https://github.com/user-attachments/assets/21b60cc9-ab4e-45ea-be56-cadb4320166e)

The total amount there doesn't make sense because the storage cost was added twice instead of the storage request cost.